### PR TITLE
remove bad imports from doctests in linalg.py

### DIFF
--- a/linalg.py
+++ b/linalg.py
@@ -38,7 +38,6 @@ def orth(A):
     Examples
     --------
 
-    >>> from dstauffman.bpe import orth
     >>> import numpy as np
 
     Full rank matrix
@@ -105,7 +104,6 @@ def subspace(A, B):
     Examples
     --------
 
-    >>> from dstauffman.bpe import subspace
     >>> import numpy as np
     >>> A = np.array([[1, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1], [1, 1, 1], [-1, 1, -1], [1, -1, -1], [-1, -1, 1]])
     >>> B = np.array([[1, 1, 1, 1], [1, -1, 1, -1],[1, 1, -1, -1], [1, -1, -1, 1], [-1, -1, -1, -1], \


### PR DESCRIPTION
These doctests failed since the import statements are no longer needed (I assume these functions used to be in BPE and you refactored them to their own linalg.py file)